### PR TITLE
Make sure sync status messages are the last items shown on editbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ep_initialized

--- a/ep.json
+++ b/ep.json
@@ -2,6 +2,9 @@
   "parts": [
     {
       "name": "main",
+      "client_hooks": {
+        "postToolbarInit": "ep_sync_status/static/js/index"
+      },
       "hooks": {
         "eejsBlock_styles": "ep_sync_status/index",
         "eejsBlock_editbarMenuLeft": "ep_sync_status/index"

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.eejsBlock_styles = function(hook_name, context, cb){
 
 exports.eejsBlock_editbarMenuLeft = function (hook_name, context, cb) {
   context.content
-    += '<li class="syncstatus" id="syncstatussyncing">Saving...</li>'
-    + '<li class="syncstatus" id="syncstatusdone">Saved.</li>';
+    += '<li class="syncstatus" id="syncstatussyncing" data-l10n-id="ep_sync_status.saving">Saving...</li>'
+    +  '<li class="syncstatus" id="syncstatusdone"    data-l10n-id="ep_sync_status.saved">Saved.</li>';
   cb();
 };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,11 @@
+var eejs = require('ep_etherpad-lite/node/eejs/');
+
 exports.eejsBlock_styles = function(hook_name, context, cb){
-   context.content += '<style type="text/css">'
-    + '.toolbar ul li.syncstatus:not(.separator) {'
-    + '  display: none;'
-    + '  line-height: 32px;'
-    + '  font-size: 14pt;'
-    + '  color: #666;'
-    + '}'
-    + '</style>';
+  context.content += '<link href="../static/plugins/ep_sync_status/static/css/editbar.css" rel="stylesheet">';
   cb();
 }
 
 exports.eejsBlock_editbarMenuLeft = function (hook_name, context, cb) {
-  context.content
-    += '<li class="syncstatus separator acl-write"></li>'
-    +  '<li class="syncstatus" id="syncstatussyncing" data-l10n-id="ep_sync_status.saving">Saving...</li>'
-    +  '<li class="syncstatus" id="syncstatusdone"    data-l10n-id="ep_sync_status.saved">Saved.</li>';
+  context.content += eejs.require('ep_sync_status/templates/syncStatus.ejs');
   cb();
 };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
 exports.eejsBlock_styles = function(hook_name, context, cb){
    context.content += '<style type="text/css">'
-    + '.toolbar ul li.syncstatus {'
+    + '.toolbar ul li.syncstatus:not(.separator) {'
     + '  display: none;'
     + '  line-height: 32px;'
-    + '  margin-left: 10px;'
     + '  font-size: 14pt;'
     + '  color: #666;'
     + '}'
-    + "</style>";
+    + '</style>';
   cb();
 }
 
 exports.eejsBlock_editbarMenuLeft = function (hook_name, context, cb) {
   context.content
-    += '<li class="syncstatus" id="syncstatussyncing" data-l10n-id="ep_sync_status.saving">Saving...</li>'
+    += '<li class="syncstatus separator acl-write"></li>'
+    +  '<li class="syncstatus" id="syncstatussyncing" data-l10n-id="ep_sync_status.saving">Saving...</li>'
     +  '<li class="syncstatus" id="syncstatusdone"    data-l10n-id="ep_sync_status.saved">Saved.</li>';
   cb();
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "ep_sync_status.saving" : "Saving...",
+  "ep_sync_status.saved" : "Saved."
+}

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "ep_sync_status.saving" : "Salvando...",
+  "ep_sync_status.saved" : "Salvo."
+}

--- a/static/css/editbar.css
+++ b/static/css/editbar.css
@@ -1,0 +1,6 @@
+.toolbar ul li.syncstatus:not(.separator) {
+  display: none;
+  line-height: 32px;
+  font-size: 14pt;
+  color: #666;
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,0 +1,15 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+exports.postToolbarInit = function(hook, context) {
+  // sync status menu items might had been added before items of other plugins were added
+  // to the menu left, so make sure they are on the right of all items to avoid moving
+  // buttons around every time the status changes
+  makeSyncStatusTheLastItemsOfMenuLeft();
+}
+
+var makeSyncStatusTheLastItemsOfMenuLeft = function() {
+  var $syncStatusMenuItems = $('.syncstatus');
+  var $lastItemOnMenuLeft = $syncStatusMenuItems.siblings().last();
+
+  $syncStatusMenuItems.insertAfter($lastItemOnMenuLeft);
+}

--- a/templates/syncStatus.ejs
+++ b/templates/syncStatus.ejs
@@ -1,0 +1,3 @@
+<li class="syncstatus separator acl-write"></li>
+<li class="syncstatus" id="syncstatussyncing" data-l10n-id="ep_sync_status.saving">Saving...</li>
+<li class="syncstatus" id="syncstatusdone"    data-l10n-id="ep_sync_status.saved">Saved.</li>


### PR DESCRIPTION
Other plugins might add more items to menu left after ep_sync_status is initialized, so their buttons would be moved right/left every time the status changes. To avoid that, make sure menu items created by this plugins are the last ones on the menu.

This PR also adds i18n + use EJS to follow [recommended standard on Etherpad documentation](http://etherpad.org/doc/v1.6.0/#index_templates).